### PR TITLE
Update HttpClientMiniStressTest.cs

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -16,6 +16,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.Http.Functional.Tests
 {
+    [Collection("MiniStress")]
     public sealed class SocketsHttpHandler_HttpClientMiniStress_NoVersion : HttpClientMiniStress
     {
         public SocketsHttpHandler_HttpClientMiniStress_NoVersion(ITestOutputHelper output) : base(output) { }
@@ -31,6 +32,7 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
+    [Collection("MiniStress")]
     [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
     public sealed class SocketsHttpHandler_HttpClientMiniStress_Http3 : HttpClientMiniStress
     {
@@ -38,12 +40,14 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion.Version30;
     }
 
+    [Collection("MiniStress")]
     public sealed class SocketsHttpHandler_HttpClientMiniStress_Http2 : HttpClientMiniStress
     {
         public SocketsHttpHandler_HttpClientMiniStress_Http2(ITestOutputHelper output) : base(output) { }
         protected override Version UseVersion => HttpVersion.Version20;
     }
 
+    [Collection("MiniStress")]
     public sealed class SocketsHttpHandler_HttpClientMiniStress_Http11 : HttpClientMiniStress
     {
         public SocketsHttpHandler_HttpClientMiniStress_Http11(ITestOutputHelper output) : base(output) { }


### PR DESCRIPTION
Currently, it's possible for 4 different instances of SingleClient_ManyGets_Sync to run in parallel, each using up to 2 x 5000 sockets, totaling in 40,000 sockets. way beyond the original intent of testing 5000 client instances. since this additional stress is random in nature, I believe it is not intentional.
This change make sure that those tests will not run in parallel, this avoids some issues I've encountered in some systems.